### PR TITLE
Dropping Scala 2.11.x support and adding support for Scala 2.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ worker*.log
 tags
 tq:q
 Stuff*
+.sbtopts

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
+version = "2.0.1"
 style = default
 lineEndings = preserve
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,13 +7,19 @@ name := """https-tracer-root"""
 
 organization in ThisBuild := "dev.profunktor"
 
-crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.8")
+crossScalaVersions in ThisBuild := Seq("2.12.9", "2.13.0")
 
 sonatypeProfileName := "dev.profunktor"
 
 promptTheme := PromptTheme(List(
   text(_ => "[http4s-tracer]", fg(64)).padRight(" λ ")
  ))
+
+def uuidDep(v: String): Seq[ModuleID] =
+  CrossVersion.partialVersion(v) match {
+    case Some((2, 13)) => Seq.empty
+    case _             => Seq(Libraries.gfcTimeuuid)
+  }
 
 lazy val commonSettings = Seq(
   startYear := Some(2018),
@@ -27,10 +33,10 @@ lazy val commonSettings = Seq(
     Libraries.fs2Core,
     Libraries.http4sServer,
     Libraries.http4sDsl,
-    Libraries.gfcTimeuuid,
     Libraries.scalaTest  % Test,
     Libraries.scalaCheck % Test
   ),
+  libraryDependencies ++= uuidDep(scalaVersion.value),
   resolvers += "Apache public" at "https://repository.apache.org/content/groups/public/",
   scalafmtOnCompile := true,
   publishTo := {
@@ -54,7 +60,6 @@ lazy val commonSettings = Seq(
 )
 
 lazy val examplesDependencies = Seq(
-  Libraries.catsPar,
   Libraries.http4sClient,
   Libraries.http4sCirce,
   Libraries.circeCore,

--- a/core/src/main/scala-2.12/dev/profunktor/tracer/GenUUID.scala
+++ b/core/src/main/scala-2.12/dev/profunktor/tracer/GenUUID.scala
@@ -14,20 +14,13 @@
  * limitations under the License.
  */
 
-package dev.profunktor.tracer.module
+package dev.profunktor.tracer
 
-import cats.Parallel
 import cats.effect.Sync
-import dev.profunktor.tracer.algebra.UserAlgebra
-import dev.profunktor.tracer.program.UserProgram
+import com.gilt.timeuuid.TimeUuid
+import dev.profunktor.tracer.Tracer.TraceId
 
-private[module] trait Programs[F[_]] {
-  def users: UserAlgebra[F]
-}
-
-final case class LivePrograms[F[_]: Parallel: Sync](
-    repos: Repositories[F],
-    clients: HttpClients[F]
-) extends Programs[F] {
-  def users: UserAlgebra[F] = new UserProgram[F](repos.users, clients.userRegistry)
+object GenUUID {
+  def make[F[_]: Sync]: F[TraceId] =
+    Sync[F].delay(TraceId(TimeUuid().toString))
 }

--- a/core/src/main/scala-2.13/dev/profunktor/tracer/GenUUID.scala
+++ b/core/src/main/scala-2.13/dev/profunktor/tracer/GenUUID.scala
@@ -14,20 +14,13 @@
  * limitations under the License.
  */
 
-package dev.profunktor.tracer.module
+package dev.profunktor.tracer
 
-import cats.Parallel
 import cats.effect.Sync
-import dev.profunktor.tracer.algebra.UserAlgebra
-import dev.profunktor.tracer.program.UserProgram
+import dev.profunktor.tracer.Tracer.TraceId
+import java.{util => ju}
 
-private[module] trait Programs[F[_]] {
-  def users: UserAlgebra[F]
-}
-
-final case class LivePrograms[F[_]: Parallel: Sync](
-    repos: Repositories[F],
-    clients: HttpClients[F]
-) extends Programs[F] {
-  def users: UserAlgebra[F] = new UserProgram[F](repos.users, clients.userRegistry)
+object GenUUID {
+  def make[F[_]: Sync]: F[TraceId] =
+    Sync[F].delay(TraceId(ju.UUID.randomUUID().toString()))
 }

--- a/core/src/main/scala/dev/profunktor/tracer/Tracer.scala
+++ b/core/src/main/scala/dev/profunktor/tracer/Tracer.scala
@@ -20,7 +20,6 @@ import cats.Applicative
 import cats.data.Kleisli
 import cats.effect.Sync
 import cats.syntax.all._
-import com.gilt.timeuuid.TimeUuid
 import org.http4s.syntax.StringSyntax
 import org.http4s.{Header, HttpApp, Request}
 
@@ -66,7 +65,7 @@ class Tracer[F[_]] private (headerName: String) {
     Kleisli { req =>
       val createId: F[(Request[F], TraceId)] =
         for {
-          id <- F.delay(TraceId(TimeUuid().toString))
+          id <- GenUUID.make[F]
           tr <- F.delay(req.putHeaders(Header(headerName, id.value)))
         } yield (tr, id)
 

--- a/examples/src/main/scala/com/github/gvolpe/tracer/Main.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/Main.scala
@@ -16,9 +16,9 @@
 
 package dev.profunktor.tracer
 
+import cats.Parallel
 import cats.effect._
-import cats.syntax.all._
-import cats.temp.par._
+import cats.implicits._
 import dev.profunktor.tracer.Trace.Trace
 import dev.profunktor.tracer.module._
 import dev.profunktor.tracer.module.tracer._
@@ -27,7 +27,7 @@ import org.http4s.server.blaze.BlazeServerBuilder
 
 import scala.concurrent.ExecutionContext
 
-class Main[F[_]: ConcurrentEffect: Par: Timer: Tracer: λ[T[_] => TracerLog[Trace[T, ?]]]] {
+class Main[F[_]: ConcurrentEffect: Parallel: Timer: Tracer: λ[T[_] => TracerLog[Trace[T, ?]]]] {
 
   val server: F[Unit] =
     BlazeClientBuilder[F](ExecutionContext.global).resource.use { client =>

--- a/examples/src/main/scala/com/github/gvolpe/tracer/http/AuthRoutes.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/http/AuthRoutes.scala
@@ -39,7 +39,7 @@ class AuthRoutes[F[_]: Sync: Tracer](users: UserAlgebra[Trace[F, ?]]) extends Ht
       Created(user -> traceId)
   }
 
-  lazy val authMiddleware: AuthMiddleware[F, String] = ???
+  lazy val authMiddleware: AuthMiddleware[F, String] = null
 
   lazy val routes: HttpRoutes[F] = Router(
     PathPrefix -> authMiddleware(httpRoutes)

--- a/examples/src/main/scala/com/github/gvolpe/tracer/module/tracer/TracedPrograms.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/module/tracer/TracedPrograms.scala
@@ -16,8 +16,8 @@
 
 package dev.profunktor.tracer.module.tracer
 
+import cats.Parallel
 import cats.effect.Sync
-import cats.temp.par._
 import cats.syntax.apply._
 import dev.profunktor.tracer.Trace.Trace
 import dev.profunktor.tracer.TracerLog
@@ -25,7 +25,7 @@ import dev.profunktor.tracer.algebra.UserAlgebra
 import dev.profunktor.tracer.model.user.{User, Username}
 import dev.profunktor.tracer.module.{LivePrograms, Programs}
 
-case class TracedPrograms[F[_]: Par: Sync: λ[T[_] => TracerLog[Trace[T, ?]]]](
+case class TracedPrograms[F[_]: Parallel: Sync: λ[T[_] => TracerLog[Trace[T, ?]]]](
     repos: TracedRepositories[F],
     clients: TracedHttpClients[F]
 ) extends Programs[Trace[F, ?]] {

--- a/examples/src/main/scala/com/github/gvolpe/tracer/program/UserProgram.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/program/UserProgram.scala
@@ -16,16 +16,15 @@
 
 package dev.profunktor.tracer.program
 
-import cats.MonadError
+import cats.{MonadError, Parallel}
 import cats.syntax.all._
-import cats.temp.par._
 import dev.profunktor.tracer.algebra.UserAlgebra
 import dev.profunktor.tracer.http.client.UserRegistry
 import dev.profunktor.tracer.model.errors.UserError._
 import dev.profunktor.tracer.model.user.{User, Username}
 import dev.profunktor.tracer.repository.algebra.UserRepository
 
-class UserProgram[F[_]: Par](
+class UserProgram[F[_]: Parallel](
     repo: UserRepository[F],
     userRegistry: UserRegistry[F]
 )(implicit F: MonadError[F, Throwable])

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,15 +3,14 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val catsPar     = "0.2.1"
-    val catsEffect  = "1.4.0"
-    val fs2         = "1.0.5"
-    val http4s      = "0.20.10"
-    val circe       = "0.11.1"
+    val catsEffect  = "2.0.0"
+    val fs2         = "2.0.0"
+    val http4s      = "0.21.0-M4"
+    val circe       = "0.12.1"
     val gfcTimeuuid = "0.0.8"
-    val log4Cats    = "0.3.0"
+    val log4Cats    = "1.0.0"
     val zio         = "1.0.0-RC12-1"
-    val zioCats     = "2.0.0.0-RC2"
+    val zioCats     = "2.0.0.0-RC3"
 
     // Test
     val scalaTest  = "3.0.8"
@@ -31,7 +30,6 @@ object Dependencies {
     def log4cats(artifact: String): ModuleID                  = "io.chrisdavenport" %% s"log4cats-$artifact" % Versions.log4Cats
     def zio(artifact: String, version: String): ModuleID      = "dev.zio"           %% artifact              % version
 
-    lazy val catsPar    = "io.chrisdavenport" %% "cats-par"    % Versions.catsPar
     lazy val catsEffect = "org.typelevel"     %% "cats-effect" % Versions.catsEffect
     lazy val fs2Core    = "co.fs2"            %% "fs2-core"    % Versions.fs2
 
@@ -58,7 +56,7 @@ object Dependencies {
 
     // Compiler
     lazy val kindProjector    = "org.typelevel" %% "kind-projector"     % Versions.kindProjector // cross CrossVersion.full
-    lazy val betterMonadicFor = "com.olegpy"     %% "better-monadic-for" % Versions.betterMonadicFor
+    lazy val betterMonadicFor = "com.olegpy"    %% "better-monadic-for" % Versions.betterMonadicFor
 
     // Runtime
     lazy val logback = "ch.qos.logback" % "logback-classic" % Versions.logback

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,6 +13,6 @@ addSbtPlugin("com.lucidchart" %  "sbt-scalafmt" % "1.16")
 
 addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.12")
 
-addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.7.27")
+addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.9.4")
 
 addSbtPlugin("com.scalapenos" % "sbt-prompt" % "1.0.2")


### PR DESCRIPTION
- Updates to latest Cats and drops `cats-par` (using `Parallel` instead).
- For Scala 2.12.x we use [gfc-timeuuid](https://github.com/saksdirect/gfc-timeuuid) and for Scala 2.13.x we fallback to the standard `java.util.UUID`.
- Updates a bunch of other deps.

Closes #109 
Closes #108 
Closes #104 
Closes #103
Closes #100 
Closes #99 