### PR TITLE
release only for upstream repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == "profunktor/http4s-tracer"
     name: Publish
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
Currently, my fork is trying to release a new version of the library when I merge to master and it fails obviously.

I think that release should only be triggered for the upstream repo. 
NOTE: The condition in the workflow hasn't been tested yet.
